### PR TITLE
Remove duplicate dependency from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
-    testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.testcontainers:mysql'
     testImplementation 'org.awaitility:awaitility'


### PR DESCRIPTION
The 'testImplementation' for 'org.testcontainers:junit-jupiter' was listed twice in the build.gradle file. This commit removes the duplicate entry to avoid redundancy and ensure a cleaner dependency management.